### PR TITLE
Add consistency test and docs for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Miner-a-curso-
 Repositorio, para ordenar y dejar registradas las diversas pruebas, proyectos, laboratorios y tareas realizados en el contexto del curso CC5205-2
+
+## Ejecutar pruebas
+
+Instala las dependencias y ejecuta `pytest` desde la raíz del proyecto:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+pytest

--- a/tests/test_data_consistency.py
+++ b/tests/test_data_consistency.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def test_anime_data_consistency():
+    df_main = pd.read_csv("anime.csv")
+    df_stats = pd.read_csv("anime-stats.csv")
+
+    assert len(df_main) == len(df_stats)
+    assert df_main["title"].iloc[0] == df_stats["title"].iloc[0]
+    assert df_main["title"].iloc[-1] == df_stats["title"].iloc[-1]


### PR DESCRIPTION
## Summary
- add pytest test to compare both CSV files
- document how to run tests with pytest
- list pandas and pytest in requirements.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68570034f0a8832b91e85619331a5719